### PR TITLE
Potential fix for code scanning alert no. 17: Missing rate limiting

### DIFF
--- a/backend/api/routes/cocktail_r.js
+++ b/backend/api/routes/cocktail_r.js
@@ -2,9 +2,17 @@
 const express = require('express')
 const cocktailCtrl = require('../controllers/cocktail_c')
 const checkToken = require('../middleware/checkJwt')
+const rateLimit = require('express-rate-limit') // Import rate-limiting middleware
 
 /*** EEXPRESS ROUTER */
 let router = express.Router()
+
+/*** RATE LIMITER */
+const deleteRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // Limit each IP to 10 delete requests per windowMs
+  message: 'Too many delete requests from this IP, please try again later.'
+})
 
 /*** COCKTAIL ROUTAGE */
 router.get('/', cocktailCtrl.getAllCocktails)
@@ -13,6 +21,6 @@ router.get('/:id([0-9]+)', cocktailCtrl.getCocktail)
 router.put('/', checkToken, cocktailCtrl.addCocktail)
 router.patch('/:id([0-9]+)', checkToken, cocktailCtrl.modifyCocktail)
 
-router.delete('/:id([0-9]+)', checkToken, cocktailCtrl.deleteCocktail)
+router.delete('/:id([0-9]+)', checkToken, deleteRateLimiter, cocktailCtrl.deleteCocktail)
 
 module.exports = router

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,8 @@
         "express": "^4.19.2",
         "jsonwebtoken": "^9.0.2",
         "mysql2": "^3.9.7",
-        "sequelize": "^6.37.3"
+        "sequelize": "^6.37.3",
+        "express-rate-limit": "^7.5.0"
     },
     "devDependencies": {
         "jest": "^29.7.0",


### PR DESCRIPTION
Potential fix for [https://github.com/CalystaR/golfhepad/security/code-scanning/17](https://github.com/CalystaR/golfhepad/security/code-scanning/17)

To address the issue, we will introduce rate-limiting middleware to the Express application. Specifically, we will use the `express-rate-limit` package to limit the number of requests that can be made to the `delete` route within a specified time window. This will help prevent abuse of the route and mitigate the risk of DoS attacks.

Steps to fix:
1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the file.
3. Define a rate-limiting middleware with appropriate settings (e.g., maximum requests and time window).
4. Apply the rate-limiting middleware to the `delete` route on line 16.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
